### PR TITLE
Corrected JSON storage (string -> serde value), added ON CONFLICT target column

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,10 +109,10 @@ impl SessionStore for DatabaseSessionStore {
                 .columns(vec![sessions::Column::Id, sessions::Column::Session])
                 .values(vec![
                     session.id().into(),
-                    serde_json::to_string(&session)?.into(),
+                    serde_json::to_value(&session)?.into(),
                 ])?
                 .on_conflict(
-                    OnConflict::new()
+                    OnConflict::column(sessions::Column::Id)
                         .update_columns([sessions::Column::Session])
                         .to_owned(),
                 ),


### PR DESCRIPTION
I had some issues with being able to store session information into a Postgres DB.
1. I got a type error when inserting the session because it was expecting a JSON blob but got text instead, and
2. I got a constraint error when inserting the session because ON CONFLICT contraints needed to be defined.

I've updated the code so that this conversion + conflict constraints work correctly.